### PR TITLE
fix(basis): B-spline LS round-trip transpose + point-wise nbasis CV (GH #33)

### DIFF
--- a/fdars-core/src/basis/projection.rs
+++ b/fdars-core/src/basis/projection.rs
@@ -116,8 +116,13 @@ pub fn fdata_to_basis(
     let btb_inv = svd_pseudoinverse(&btb)?;
     let proj = btb_inv * b_mat.transpose();
 
-    let coefs: Vec<f64> = iter_maybe_parallel!(0..n)
-        .flat_map(|i| {
+    // Per-curve coefficient rows. Collect as `Vec<Vec<f64>>` (one row per curve)
+    // and scatter into the column-major FdMatrix via `[(i, k)]` indexing. The
+    // previous code built a curve-major flat buffer and passed it to
+    // `from_column_major`, which transposes/scrambles the result whenever
+    // `n > 1` (it round-trips only for a single curve) — GH #33.
+    let rows: Vec<Vec<f64>> = iter_maybe_parallel!(0..n)
+        .map(|i| {
             let curve: Vec<f64> = (0..m).map(|j| data[(i, j)]).collect();
             (0..actual_nbasis)
                 .map(|k| {
@@ -131,9 +136,15 @@ pub fn fdata_to_basis(
         })
         .collect();
 
+    let mut coefficients = FdMatrix::zeros(n, actual_nbasis);
+    for (i, row) in rows.iter().enumerate() {
+        for (k, &c) in row.iter().enumerate() {
+            coefficients[(i, k)] = c;
+        }
+    }
+
     Some(BasisProjectionResult {
-        coefficients: FdMatrix::from_column_major(coefs, n, actual_nbasis)
-            .expect("dimension invariant: data.len() == n * m"),
+        coefficients,
         n_basis: actual_nbasis,
     })
 }
@@ -183,8 +194,12 @@ pub fn basis_to_fdata(
 
     let actual_nbasis = basis.len() / m;
 
-    let flat: Vec<f64> = iter_maybe_parallel!(0..n)
-        .flat_map(|i| {
+    // Per-curve reconstruction rows, scattered into the column-major FdMatrix
+    // via `[(i, j)]`. As in `fdata_to_basis`, building a curve-major flat buffer
+    // and passing it to `from_column_major` transposes the output for n > 1
+    // (GH #33).
+    let rows: Vec<Vec<f64>> = iter_maybe_parallel!(0..n)
+        .map(|i| {
             (0..m)
                 .map(|j| {
                     let mut sum = 0.0;
@@ -197,7 +212,13 @@ pub fn basis_to_fdata(
         })
         .collect();
 
-    FdMatrix::from_column_major(flat, n, m).expect("dimension invariant: data.len() == n * m")
+    let mut out = FdMatrix::zeros(n, m);
+    for (i, row) in rows.iter().enumerate() {
+        for (j, &v) in row.iter().enumerate() {
+            out[(i, j)] = v;
+        }
+    }
+    out
 }
 
 /// Reconstruct functional data from basis coefficients (legacy i32 interface).

--- a/fdars-core/src/basis/tests.rs
+++ b/fdars-core/src/basis/tests.rs
@@ -299,6 +299,66 @@ fn test_basis_roundtrip() {
     assert!(max_error < 0.5, "Roundtrip error too large: {}", max_error);
 }
 
+/// Regression for GH #33: `fdata_to_basis` / `basis_to_fdata` transposed the
+/// result for `n > 1` curves (a curve-major buffer was fed to a column-major
+/// constructor), so multi-curve round-trips were worse than a constant fit,
+/// did not improve with `n_basis`, and left the data range. `n = 1` masked it.
+#[test]
+fn test_bspline_roundtrip_multi_curve_is_least_squares() {
+    let m = 80;
+    let n = 6;
+    let t = uniform_grid(m);
+    let mut data = FdMatrix::zeros(n, m);
+    for i in 0..n {
+        let phase = 0.4 * i as f64;
+        let slope = 0.3 * i as f64;
+        for j in 0..m {
+            data[(i, j)] = (2.0 * PI * t[j] + phase).sin() + slope * t[j];
+        }
+    }
+
+    // Per-curve constant fit — any least-squares basis fit must beat this.
+    let mut const_ss = 0.0;
+    let (mut dmin, mut dmax) = (f64::INFINITY, f64::NEG_INFINITY);
+    for i in 0..n {
+        let mean = (0..m).map(|j| data[(i, j)]).sum::<f64>() / m as f64;
+        for j in 0..m {
+            const_ss += (data[(i, j)] - mean).powi(2);
+            dmin = dmin.min(data[(i, j)]);
+            dmax = dmax.max(data[(i, j)]);
+        }
+    }
+    let const_rms = (const_ss / (n * m) as f64).sqrt();
+
+    let rms_at = |nb: usize| -> f64 {
+        let proj = fdata_to_basis_1d(&data, &t, nb, 0).unwrap();
+        let recon = basis_to_fdata_1d(&proj.coefficients, &t, proj.n_basis, 0);
+        let mut ss = 0.0;
+        for i in 0..n {
+            for j in 0..m {
+                let v = recon[(i, j)];
+                assert!(
+                    v > dmin - 1.0 && v < dmax + 1.0,
+                    "nb={nb}: reconstruction {v:.2} left data range [{dmin:.2}, {dmax:.2}]"
+                );
+                ss += (data[(i, j)] - v).powi(2);
+            }
+        }
+        (ss / (n * m) as f64).sqrt()
+    };
+
+    let rms_lo = rms_at(8);
+    let rms_hi = rms_at(25);
+    assert!(
+        rms_lo < const_rms,
+        "nb=8 LS residual {rms_lo:.4} must beat constant fit {const_rms:.4}"
+    );
+    assert!(
+        rms_hi < rms_lo,
+        "more basis functions must fit better: nb=25 {rms_hi:.4} !< nb=8 {rms_lo:.4}"
+    );
+}
+
 #[test]
 fn test_basis_to_fdata_empty_input() {
     let empty = FdMatrix::zeros(0, 0);

--- a/fdars-core/src/smooth_basis.rs
+++ b/fdars-core/src/smooth_basis.rs
@@ -671,8 +671,15 @@ fn evaluate_nbasis_cv(
     n_folds: usize,
 ) -> Vec<f64> {
     let (n, m) = data.shape();
-    let n_folds = n_folds.max(2);
-    let folds = crate::cv::create_folds(n, n_folds, 42);
+    // Cross-validate over TIME POINTS, not curves. Leaving out curves is
+    // ill-posed for per-curve basis fitting — each curve has its own
+    // coefficients, so a held-out curve can only be scored against its own data,
+    // which is an in-sample residual that decreases monotonically in `nbasis`
+    // and always selects the largest candidate (GH #33). Holding out points and
+    // predicting them from a fit on the remaining points gives a genuine
+    // predictive score that penalizes overfitting and shows an interior minimum.
+    let n_folds = n_folds.max(2).min(m);
+    let point_folds = crate::cv::create_folds(m, n_folds, 42);
     let mut scores = Vec::with_capacity(nbasis_range.len());
 
     for &nb in nbasis_range {
@@ -684,53 +691,48 @@ fn evaluate_nbasis_cv(
             BasisType::Bspline { order } => bspline_penalty_matrix(argvals, nb, *order, 2),
             BasisType::Fourier { period } => fourier_penalty_matrix(nb, *period, 2),
         };
+        let (basis_flat, actual_k) = evaluate_basis(argvals, basis_type, nb);
+        let b_full = DMatrix::from_column_slice(m, actual_k, &basis_flat);
+        let r_mat = DMatrix::from_column_slice(actual_k, actual_k, &penalty);
 
-        let mut total_mse = 0.0;
-        let mut total_count = 0;
+        let mut total_se = 0.0;
+        let mut count = 0usize;
 
         for fold in 0..n_folds {
-            let (train_idx, test_idx) = crate::cv::fold_indices(&folds, fold);
-            if train_idx.is_empty() || test_idx.is_empty() {
+            let (train_pts, test_pts) = crate::cv::fold_indices(&point_folds, fold);
+            if train_pts.is_empty() || test_pts.is_empty() {
                 continue;
             }
-            let train_data = crate::cv::subset_rows(data, &train_idx);
-            let fdpar = FdPar {
-                basis_type: basis_type.clone(),
-                nbasis: nb,
-                lambda,
-                lfd_order: 2,
-                penalty_matrix: penalty.clone(),
+            // Basis rows at the train/test points, and the projection operator
+            // built from the training points only (independent of any curve).
+            let b_train = b_full.select_rows(train_pts.iter());
+            let b_test = b_full.select_rows(test_pts.iter());
+            let btb = b_train.transpose() * &b_train;
+            let ridge_eps = 1e-10;
+            let system: DMatrix<f64> =
+                &btb + lambda * &r_mat + ridge_eps * DMatrix::<f64>::identity(actual_k, actual_k);
+            let Some(system_inv) = invert_penalized_system(&system, actual_k) else {
+                continue;
             };
+            let proj = &system_inv * b_train.transpose(); // (k x |train|)
 
-            if let Ok(train_result) = smooth_basis(&train_data, argvals, &fdpar) {
-                let (basis_flat, actual_k) = evaluate_basis(argvals, basis_type, nb);
-                let b_mat = DMatrix::from_column_slice(m, actual_k, &basis_flat);
-                let r_mat =
-                    DMatrix::from_column_slice(actual_k, actual_k, &train_result.penalty_matrix);
-                let btb = b_mat.transpose() * &b_mat;
-                let ridge_eps = 1e-10;
-                let system: DMatrix<f64> = &btb
-                    + lambda * &r_mat
-                    + ridge_eps * DMatrix::<f64>::identity(actual_k, actual_k);
-
-                if let Some(system_inv) = invert_penalized_system(&system, actual_k) {
-                    let proj = &system_inv * b_mat.transpose();
-                    for &ti in &test_idx {
-                        let curve: Vec<f64> = (0..m).map(|j| data[(ti, j)]).collect();
-                        let y_vec = nalgebra::DVector::from_vec(curve.clone());
-                        let coefs = &proj * &y_vec;
-                        let fitted = &b_mat * &coefs;
-                        let mse: f64 =
-                            (0..m).map(|j| (curve[j] - fitted[j]).powi(2)).sum::<f64>() / m as f64;
-                        total_mse += mse;
-                        total_count += 1;
-                    }
+            for i in 0..n {
+                let y_train = nalgebra::DVector::from_iterator(
+                    train_pts.len(),
+                    train_pts.iter().map(|&j| data[(i, j)]),
+                );
+                let coefs = &proj * &y_train;
+                let pred = &b_test * &coefs; // predictions at held-out points
+                for (t_idx, &j) in test_pts.iter().enumerate() {
+                    let err = data[(i, j)] - pred[t_idx];
+                    total_se += err * err;
+                    count += 1;
                 }
             }
         }
 
-        if total_count > 0 {
-            scores.push(total_mse / f64::from(total_count));
+        if count > 0 {
+            scores.push(total_se / count as f64);
         } else {
             scores.push(f64::INFINITY);
         }
@@ -1080,6 +1082,49 @@ mod tests {
         let res = result.unwrap();
         assert!(nbasis_range.contains(&res.optimal_nbasis));
         assert_eq!(res.criterion, BasisCriterion::Cv);
+    }
+
+    /// Regression for GH #33: the CV path scored held-out curves against their
+    /// own data (no true hold-out), so scores fell monotonically in `n_basis`
+    /// and it always selected the maximum candidate. With point-wise CV,
+    /// overfitting the noise is penalized and the maximum is not chosen.
+    #[test]
+    fn test_basis_nbasis_cv_penalizes_overfitting() {
+        let m = 120;
+        let n = 6;
+        let t = uniform_grid(m);
+        let mut data = FdMatrix::zeros(n, m);
+        for i in 0..n {
+            for j in 0..m {
+                // Smooth signal + deterministic pseudo-noise.
+                let noise = 0.2 * (((i * 31 + j * 17) % 13) as f64 / 13.0 - 0.5);
+                data[(i, j)] = (2.0 * PI * t[j]).sin() + noise;
+            }
+        }
+
+        let nbasis_range: Vec<usize> = vec![5, 8, 12, 20, 30];
+        let res = basis_nbasis_cv(
+            &data,
+            &t,
+            &nbasis_range,
+            &BasisType::Bspline { order: 4 },
+            BasisCriterion::Cv,
+            5,
+            1e-6,
+        )
+        .unwrap();
+
+        assert_ne!(
+            res.optimal_nbasis, 30,
+            "CV must not always select the maximum n_basis (GH #33); scores={:?}",
+            res.scores
+        );
+        let monotone_decreasing = res.scores.windows(2).all(|w| w[1] <= w[0] + 1e-12);
+        assert!(
+            !monotone_decreasing,
+            "CV scores must not be monotone-decreasing in n_basis; scores={:?}",
+            res.scores
+        );
     }
 
     // ============== Comprehensive additional tests ==============


### PR DESCRIPTION
Fixes #33.

Two independent defects in the 1-D B-spline basis path.

## Bug 1 — `fdata_to_basis` / `basis_to_fdata` transpose the result for `n > 1`
Both functions built a **curve-major** flat buffer (`[i*K + k]`, `[i*m + j]`) and passed it to `FdMatrix::from_column_major`, which reads it **column-major** (`[row + col*n]`). For a single curve the two layouts coincide (why a smooth 1-curve round-trip was perfect), but for multiple curves the coefficients and reconstruction were transposed/scrambled — hence residuals *worse than a constant fit*, flat in `n_basis`, and outside the data range on the 35×365 weather matrix. The least-squares solve `(BᵀB)⁻¹Bᵀ` itself is correct.

**Fix:** collect per-curve rows and scatter them into the matrix via `[(i, k)]` / `[(i, j)]` indexing (column-major-correct), preserving parallelism.

## Bug 2 — `basis_nbasis_cv` (`Cv`) always selects the maximum `n_basis`
`evaluate_nbasis_cv` fit each fold's *training* curves but threw those coefficients away, then projected every **test** curve onto the basis using **its own data** and scored it against itself — a pure in-sample residual with no hold-out, monotone-decreasing in `n_basis`. (Leaving out whole *curves* is ill-posed for per-curve basis fitting: a held-out curve can't be predicted from other curves' coefficients.)

**Fix:** cross-validate over **time points** — fit coefficients on the retained points, predict the held-out points, score the prediction error. This is a genuine predictive criterion that penalizes overfitting and shows an interior minimum. The GCV/AIC/BIC paths were already correct and are unchanged.

## Tests
- `test_bspline_roundtrip_multi_curve_is_least_squares`: multi-curve round-trip beats a constant fit, improves with `n_basis`, stays in range.
- `test_basis_nbasis_cv_penalizes_overfitting`: CV no longer selects the max `n_basis` (and scores aren't monotone) on smooth+noise data.
- Full basis (149) + smooth_basis (106) + R-validation (173) + validate_new_modules (56) pass; clippy `--all-targets` + rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)